### PR TITLE
Add interactive query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # delbinobj
-Command-line tool that scans a specified directory for .NET 
-project files (.csproj) and deletes the associated bin, obj 
-and optionally .vs directories. 
+Command-line tool that scans a specified directory for .NET
+project files (.csproj) and deletes the associated bin, obj
+and optionally .vs directories.
 
 ## Run arguments
 ### How to use?
@@ -9,7 +9,7 @@ and optionally .vs directories.
 
 ### Run arguments:
 1.  -?, -h, --help        Show help and usage information
-1.  --version             Wyœwietl informacje o wersji
+1.  --version             Wywietl informacje o wersji
 1.  -p, --startup-path    Directory where command will look for *.csproj file to locate bin and obj folders to delete [default: .]
 1.  -r, --recursive       If present, command will scan startup directory and all directories below for *.csproj files
 1.  -vs, --include-vs     If present, command will delete .vs directory from solution directory
@@ -18,3 +18,5 @@ and optionally .vs directories.
 1.  -v, --verbose         If present, command will print verbose output to console
 1.  -ui, --userinterface  If present, progress bar will be presented
 1.  -l, --log-file        If present, command will log output to specified file
+1.  -q, --query           If present, command will prompt for all other options
+

--- a/delbinobj/delbinobj/Application.cs
+++ b/delbinobj/delbinobj/Application.cs
@@ -18,35 +18,39 @@ internal class Application
         var startUpOption = new Option<string>(name: "--startup-path", aliases: ["-p"])
         {
             Description = "Directory where command will look for *.csproj file to locate bin and obj folders to delete",
-            DefaultValueFactory = _ => "."
+            DefaultValueFactory = _ => ".",
         };
 
         var verboseOption = new Option<bool>("--verbose", aliases: ["-v"]) {
-            Description = "If present, command will print verbose output to console"
+            Description = "If present, command will print verbose output to console",
         };
 
         var recursiveOption = new Option<bool>("--recursive", aliases: ["-r"]) {
-            Description = "If present, command will scan startup directory and all directories below for *.csproj files"
+            Description = "If present, command will scan startup directory and all directories below for *.csproj files",
         };
 
         var dotvsDirOption = new Option<bool>("--include-vs", aliases: ["-vs"]) {
-            Description = "If present, command will delete .vs directory from solution directory"
+            Description = "If present, command will delete .vs directory from solution directory",
         };
 
         var logFileOption = new Option<string?>("--log-file", aliases: ["-l"]) {
-            Description = "If present, command will log output to specified file"
+            Description = "If present, command will log output to specified file",
         };
 
         var softDeletePathOption = new Option<string?>("--softdelete", aliases: ["-sd"]) {
-            Description = "If present, the command will move (instead of delete) found directories to the directory specified in this argument, maintaining the relationship to the start-up path"
+            Description = "If present, the command will move (instead of delete) found directories to the directory specified in this argument, maintaining the relationship to the start-up path",
         };
 
         var dryRunOption = new Option<bool>("--dryrun", aliases: ["-dr"]) {
-            Description = "If present, command will not delete or move anything, just print what would processed"
+            Description = "If present, command will not delete or move anything, just print what would processed",
         };
 
         var uiOption = new Option<bool>("--userinterface", aliases: ["-ui"]) {
-            Description = "If present, progress bar will be presented"
+            Description = "If present, progress bar will be presented",
+        };
+
+        var queryOption = new Option<bool>("--query", aliases: ["-q"]) {
+            Description = "If present, the command will interactively ask for all options",
         };
 
         return new RootCommand("Deletes bin and obj directories in a .NET project(s)")
@@ -59,13 +63,15 @@ internal class Application
             verboseOption,
             uiOption,
             logFileOption,
+            queryOption,
         };
     }
 
     int RootHandler(ParseResult parseResult)
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
-        Context context = Context.Build(parseResult);
+        bool query = parseResult.GetResult("--query")?.GetValue<bool?>("--query") ?? false;
+        Context context = query ? Context.BuildInteractive() : Context.Build(parseResult);
         Logger log = Logger.Build(context);
         var shell = new Shell(log, context);
         var runRslt = shell.Run();
@@ -74,3 +80,4 @@ internal class Application
         return runRslt;
     }
 }
+

--- a/delbinobj/delbinobj/Context.cs
+++ b/delbinobj/delbinobj/Context.cs
@@ -28,6 +28,42 @@ internal class Context
         return context;
     }
 
+    internal static Context BuildInteractive()
+    {
+        static bool AskBool(string question)
+        {
+            Console.Write($"{question} (y/N): ");
+            var answer = Console.ReadLine();
+            return answer?.Trim().ToLowerInvariant() is "y" or "yes";
+        }
+
+        static string? AskString(string question)
+        {
+            Console.Write($"{question}: ");
+            var answer = Console.ReadLine();
+            return string.IsNullOrWhiteSpace(answer) ? null : answer;
+        }
+
+        string? startPath = AskString("Startup path [.]");
+        startPath = string.IsNullOrWhiteSpace(startPath) ? "." : startPath;
+        var context = new Context(startPath);
+        context.IsRecursive = AskBool("Scan recursively");
+        context.IncludeDotVs = AskBool("Include .vs");
+        context.SoftDeletePath = AskString("Soft delete directory (leave empty to delete)");
+        context.IsDryRun = AskBool("Dry run");
+        context.IsVerbose = AskBool("Verbose output");
+        context.ShowUI = AskBool("Show progress bar");
+        context.LogFilePath = AskString("Log file path (leave empty for none)");
+
+        if (context.SoftDelete)
+        {
+            context.SoftDeletePath = Path.Combine(context.StartPath!, context.SoftDeletePath!);
+            context.SoftDeletePath = new DirectoryInfo(context.SoftDeletePath).FullName;
+        }
+
+        return context;
+    }
+
     internal Context(string startPath)
     {
         StartPath = startPath;


### PR DESCRIPTION
## Summary
- add `--query`/`-q` argument to prompt users for all other options
- implement interactive context builder asking for each command parameter
- document new query option in README

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d7986f574832097d71a722c0aedc6